### PR TITLE
Dockerfile and README touchups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/tags
+/fonts/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM alpine:3.15
+
+RUN mkdir m 0750 -p /app/fonts && \
+  apk add python3 py3-pillow bash
+
+COPY ./mcm2img.py /app/mcm2img.py
+COPY ./entrypoint.sh /app/entrypoint.sh
+
+WORKDIR /app
+VOLUME /app/fonts
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -6,15 +6,43 @@ The Maxim format is documented here: https://www.maximintegrated.com/en/design/t
 
 Useful for: previewing fonts, converting fonts for use in other applications, etc.
 
-# Use
+# Usage
 
-`python3 mcm2img.py mcmfile.mcm font.bin [rawfmt] [R] [G] [B]`
+    python3 mcm2img.py mcmfile.mcm font.bin [rawfmt] [R] [G] [B]
 
-eg : `python3 mcm2img.py betaflight.mcm font.bin RGBA 0 255 0` for green font colour
+Example:
+
+    python3 mcm2img.py betaflight.mcm font.bin RGBA 0 255 0` for green font colour
 
 mcmfile.mcm file can found in the Configurator for your flight controller of choice.
 
 For Betaflight, this is at `betaflight-configurator*\resources\osd\1`
 
 
-if rawfmt is specified, it's one of the (many) raw bitmap formats supported by Pillow: https://github.com/python-pillow/Pillow/blob/main/src/libImaging/Unpack.c#L1483 . RGBA is probably the most common thing you will want here.
+If rawfmt is specified, it's one of the (many) raw bitmap formats supported by Pillow: https://github.com/python-pillow/Pillow/blob/main/src/libImaging/Unpack.c#L1483 . RGBA is probably the most common thing you will want here.
+
+# Docker
+
+The docker container will automatically convert all .mcm fonts found in `/app/fonts` with mcm2img.py
+
+## Volumes
+| Volume | Path       |
+|:-------|-----------:|
+| fonts  | /app/fonts |
+
+## Environment variables
+| Variable | Comment                                           | Default     |
+|:---------|---------------------------------------------------|------------:|
+| RGB      | Used to override the colour of the converted font | 255 255 255 |
+
+
+## Building
+
+To build the docker image locally please use the following command:
+
+    docker build . -t mcm2img:latest
+
+## Running
+Copy the font files (.mcm only) somewhere and execute the following command:
+
+    docker run -v ${PWD}/fonts:/app/fonts -it mcm2img:latest

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -e
+set -E
+set -u
+
+for font in /app/fonts/*.mcm; do
+	bin="${font/#mcm/bin}"
+	echo "Converting ${font} -> ${bin}"
+	python3 /app/mcm2img.py "${font}" "${bin}" RGBA ${RGB:-255 255 255}
+done


### PR DESCRIPTION
This commit aims to provide a docker image that can automatically
convert all .mcm files found in the volume /app/fonts with the help of
mcm2img.py. It does not yet include Github Actions to build and push the
image to a container registry.