### PR TITLE
Add GitHub Actions to automate the process of converting mcm fonts

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,30 @@
+---
+name: docker
+
+on:
+  push:
+    branches:
+      - 'main'
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/mcm2img:latest

--- a/.github/workflows/fonts.yml
+++ b/.github/workflows/fonts.yml
@@ -1,0 +1,53 @@
+---
+name: fonts
+
+on: push
+
+jobs:
+  fonts:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Clone betaflight configurator
+        uses: GuillaumeFalourd/clone-github-repo-action@v2
+        with:
+          owner: 'betaflight'
+          repository: 'betaflight-configurator'
+      - name: Clone iNav configurator
+        uses: GuillaumeFalourd/clone-github-repo-action@v2
+        with:
+          owner: 'iNavFlight'
+          repository: 'inav-configurator'
+      - name: copy fonts
+        run: |
+          mkdir -p ./fonts/{betaflight,inav}
+          find betaflight-configurator -iname \*.mcm -exec cp -v {} ./fonts/betaflight/ \;
+          find inav-configurator -iname \*.mcm -exec cp -v {} ./fonts/inav/ \;
+      - uses: addnab/docker-run-action@v3
+        with:
+          registry: hub.docker.com
+          image: ${{ secrets.DOCKERHUB_USERNAME }}/mcm2img:latest
+          options: -v ${{ github.workspace }}/fonts:/app/fonts
+          run: bash /app/entrypoint.sh
+      - name: copy bins
+        run: |
+          mkdir -p ./dist/{betaflight,inav}
+          find ./fonts/betaflight -type f -iname \*.bin -exec cp -v {} ./dist/betaflight/ \;
+          find ./fonts/inav -type f -iname \*.bin -exec cp -v {} ./dist/inav/ \;
+          find ./dist -type f -ls
+          tar cfvz mcm2img-fonts.tar.gz dist
+      - name: archive tarball
+        uses: actions/upload-artifact@v3
+        with:
+          name: mcm2img-fonts
+          path: |
+            dist
+      - uses: "marvinpinto/action-automatic-releases@latest"
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          automatic_release_tag: "latest"
+          prerelease: true
+          title: "Development Build"
+          files: |
+            mcm2img-fonts.tar.gz

--- a/.github/workflows/fonts.yml
+++ b/.github/workflows/fonts.yml
@@ -1,7 +1,9 @@
 ---
 name: fonts
 
-on: push
+on:
+  schedule:
+    - cron: '30 3 * * *'
 
 jobs:
   fonts:

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /tags
 /fonts/*
+/betaflight-configurator
+/inav-configurator

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM alpine:3.15
 
 RUN mkdir m 0750 -p /app/fonts && \
-  apk add python3 py3-pillow bash
+  apk add --update-cache python3 py3-pillow bash && \
+  rm -rf /var/cache/apk/*
 
 COPY ./mcm2img.py /app/mcm2img.py
 COPY ./entrypoint.sh /app/entrypoint.sh

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,8 +4,8 @@ set -e
 set -E
 set -u
 
-for font in /app/fonts/*.mcm; do
-	bin="${font/#mcm/bin}"
+for font in $(find /app/fonts -type f -name \*.mcm); do
+	bin="${font/.mcm/}"
 	echo "Converting ${font} -> ${bin}"
 	python3 /app/mcm2img.py "${font}" "${bin}" RGBA ${RGB:-255 255 255}
 done


### PR DESCRIPTION
This PR aims to provide an up to date Docker image for mcm2img.py as well as daily fonts that can be used by everyone without much hassle or python knowledge.

The docker image will be built only when a push on the default branch has happened, i.e. a pull request has been merged.
The fonts will be built during the night every day and a pre-release will be created with the converted fonts.

You will have to create a new token on hub.docker.com and save it as a secret in the repo:

- DOCKERHUB_USERNAME -> username for dockerhub
- DOCKERHUB_TOKEN -> access token